### PR TITLE
Fix syntax to turn off cherrypy.engine.timeout_monitor

### DIFF
--- a/Gazee.py
+++ b/Gazee.py
@@ -235,7 +235,7 @@ def main():
 
     cherrypy.config.update(options_dict)
 
-    cherrypy.engine.timeout_monitor.on: False
+    cherrypy.engine.timeout_monitor.unsubscribe()
     cherrypy.tree.mount(Gazee(), '/', config=conf)
 
     logging.info("Gazee Started")


### PR DESCRIPTION
See: http://docs.cherrypy.org/en/latest/advanced.html#timeout-monitor

It looks like the former method would make sense if you were defining it within either the config dictionary above (maybe?) or within a config file that cherrypy would load. However, changing it to this (which looks to be the suggested way to do this within straight python) keeps desired behavior as well as it looks like Python 3.5 (at least) will also now run gazee (have only done a quick run through all visible features and none broke).