### PR TITLE
move from basic_auth to auth_basic for cherrypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/*
 ~*
 *.swp
 .devnotes
+.idea/

--- a/Gazee.py
+++ b/Gazee.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #  This file is part of Gazee.
 #
 #  Gazee is free software: you can redistribute it and/or modify
@@ -155,10 +156,9 @@ def main():
                 'tools.sessions.timeout': 1440,
                 'tools.sessions.storage_class': cherrypy.lib.sessions.FileSession,
                 'tools.sessions.storage_path': os.path.join(gazee.DATA_DIR, "sessions"),
-                'tools.basic_auth.on': True,
-                'tools.basic_auth.realm': 'Gazee',
-                'tools.basic_auth.users': gazee.authmech.getPassword,
-                'tools.basic_auth.encrypt': gazee.authmech.hashPass,
+                'tools.auth_basic.on': True,
+                'tools.auth_basic.realm': 'Gazee',
+                'tools.auth_basic.checkpassword': gazee.authmech.checkPassword,
                 'request.show_tracebacks': False
             },
             '/static': {
@@ -189,10 +189,9 @@ def main():
                 'tools.sessions.timeout': 1440,
                 'tools.sessions.storage_class': cherrypy.lib.sessions.FileSession,
                 'tools.sessions.storage_path': os.path.join(gazee.DATA_DIR, "sessions"),
-                'tools.basic_auth.on': True,
-                'tools.basic_auth.realm': 'Gazee',
-                'tools.basic_auth.users': gazee.authmech.getPassword,
-                'tools.basic_auth.encrypt': gazee.authmech.hashPass,
+                'tools.auth_basic.on': True,
+                'tools.auth_basic.realm': 'Gazee',
+                'tools.auth_basic.checkpassword': gazee.authmech.checkPassword,
                 'request.show_tracebacks': False
             },
             '/static': {

--- a/gazee/authmech.py
+++ b/gazee/authmech.py
@@ -22,10 +22,10 @@ from pathlib import Path
 
 import gazee
 
-# This is the function called when a user logs in, it returns their hashed password from the DB for checking by CherryPys auth mechanism.
+# This is the function called when a user logs in, it's given a realm (Gazee) and the user inputted username and password
+# We get the hashed password from the DB for username and then check that against the hashed version of the inputted password
 
-
-def getPassword(username):
+def checkPassword(realm, username, password):
 
     userstring = str(username)
 
@@ -38,15 +38,14 @@ def getPassword(username):
 
     c.execute('SELECT {pw} FROM {tn} WHERE {un}=?'.format(pw=gazee.PASSWORD, tn=gazee.USERS, un=gazee.USERNAME), (userstring,))
     passinit = c.fetchone()
-    if passinit is not None:
-        password = passinit[0]
-    else:
-        password = 'nil'
+    if passinit is None:
+        return False
 
+    db_password = passinit[0]
     connection.commit()
     connection.close()
 
-    return password
+    return db_password == hashPass(password)
 
 
 def getUserLevel(username):


### PR DESCRIPTION
the basic_auth authentication method was depreciated in favor of the newer auth_basic method as outlined in cherrypy/cherrypy#913 and cherrypy/cherrypy#914. See the [docs](http://docs.cherrypy.org/en/latest/basics.html#basic) on how this method works.