### PR TITLE
add Materialize toasts to all setting ajax requests

### DIFF
--- a/gazee/authmech.py
+++ b/gazee/authmech.py
@@ -99,6 +99,8 @@ def changePass(user, password):
 
 
 def addUser(user, password, ut):
+    logging.basicConfig(level=logging.DEBUG, filename=os.path.join(gazee.DATA_DIR, 'gazee.log'))
+    logger = logging.getLogger(__name__)
     hashedPass = hashPass(password)
 
     # Here we set the db file path.
@@ -107,13 +109,14 @@ def addUser(user, password, ut):
     # Here we make the inital DB connection that we will be using throughout this function.
     connection = sqlite3.connect(str(db))
     c = connection.cursor()
+    try:
+        c.execute('INSERT INTO {tn} ({un}, {pw}, {ut}) VALUES (?,?,?)'.format(tn=gazee.USERS, un=gazee.USERNAME, pw=gazee.PASSWORD, ut=gazee.TYPE), (user, hashedPass, ut,))
+    except sqlite3.IntegrityError:
+        logger.info("User %s Already Exists" % user)
+        return False
+    finally:
+        connection.commit()
+        connection.close()
 
-    c.execute('INSERT INTO {tn} ({un}, {pw}, {ut}) VALUES (?,?,?)'.format(tn=gazee.USERS, un=gazee.USERNAME, pw=gazee.PASSWORD, ut=gazee.TYPE), (user, hashedPass, ut,))
-
-    connection.commit()
-    connection.close()
-
-    logging.basicConfig(level=logging.DEBUG, filename=os.path.join(gazee.DATA_DIR, 'gazee.log'))
-    logger = logging.getLogger(__name__)
     logger.info("User %s Added" % (user))
-    return
+    return True

--- a/gazee/db.py
+++ b/gazee/db.py
@@ -40,7 +40,7 @@ def dbCreation():
         c.execute("ALTER TABLE {tn} ADD COLUMN '{cn}'".format(tn=gazee.ALL_COMICS, cn=gazee.INSERT_DATE))
 
         # Create Users colume and necessary columns.
-        c.execute('CREATE TABLE {tn} ({nf} {ft})'.format(tn=gazee.USERS, nf=gazee.USERNAME, ft="TEXT"))
+        c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY KEY)'.format(tn=gazee.USERS, nf=gazee.USERNAME, ft="TEXT"))
         c.execute("ALTER TABLE {tn} ADD COLUMN '{cn}' {ft}".format(tn=gazee.USERS, cn=gazee.PASSWORD, ft="TEXT"))
         c.execute("ALTER TABLE {tn} ADD COLUMN '{cn}' {ft}".format(tn=gazee.USERS, cn=gazee.TYPE, ft="TEXT"))
 

--- a/gazee/versioning.py
+++ b/gazee/versioning.py
@@ -51,17 +51,23 @@ def updateApp():
 
         repo = git.Repo(os.path.dirname(gazee.FULL_PATH))
         o = repo.remotes.origin
-        o.pull()
+        try:
+            o.pull()
+        except git.exc.GitCommandError:
+            logger.exception('Failed to pull version')
+            os.rename('public/css/style.css.bak', 'public/css/style.css')
+            return False
 
         if os.path.exists('public/css/style.css'):
-            with open('public/css/style.css') as f:
+            with open('public/css/style.css', 'r+') as f:
                 style = f.read()
-
-            with open('public/css/style.css', "w") as f:
+                f.seek(0)
                 style = style.replace("757575", gazee.MAIN_COLOR)
                 style = style.replace("BDBDBD", gazee.ACCENT_COLOR)
                 style = style.replace("FFFFFF", gazee.WEB_TEXT_COLOR)
                 f.write(style)
+                f.truncate()
+
             os.remove('public/css/style.css.bak')
         else:
             os.rename('public/css/style.css.bak', 'public/css/style.css')

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -265,6 +265,7 @@ i {
     top: 90%;
     right: 50%;
     transform: translate(50%, 0);
+    white-space: nowrap;
   }
 }
 
@@ -274,5 +275,6 @@ i {
     top: 90%;
     right: 50%;
     transform: translate(50%, 0);
+    white-space: nowrap;
   }
 }

--- a/public/html/settings.html
+++ b/public/html/settings.html
@@ -103,13 +103,8 @@
                 <thead>
                 <tbody>
                   <tr>
-        % if sip:
-                    <td>In Progress</td>
+                    <td id="scan-status">${"In Progress" if sip else "Not Running"}</td>
                     <td>${scantime}</td>
-        % else:
-                    <td>Not Running</td>
-                    <td>${scantime}</td>
-        % endif
                     <td>${noc}</td>
                   </tr>
                 </tbody>
@@ -147,7 +142,7 @@
                       <th>User Type</th>
                     </tr>
                   <thead>
-                  <tbody>
+                  <tbody id="user-rows">
 % for u in users:
                     <tr id="user-${u['User']}">
                       <td>${u['User']}</td>
@@ -201,19 +196,19 @@
             <div class="row">
               <div class="input-field col s2">
                 <input type="text" name="mainColor" value='${gazee.MAIN_COLOR}' class="jscolor" >
-                <label for="mainColor">Main Color</label>
+                <label for="mainColor" style="padding-bottom: 5px">Main Color</label>
               </div>
             </div>
             <div class="row">
               <div class="input-field col s2">
                 <input type="text" name="accentColor" value='${gazee.ACCENT_COLOR}' class="jscolor" >
-                <label for="accentColor">Accent Color</label>
+                <label for="accentColor" style="padding-bottom: 5px">Accent Color</label>
               </div>
             </div>
             <div class="row">
               <div class="input-field col s2">
                 <input type="text" name="webTextColor" value='${gazee.WEB_TEXT_COLOR}' class="jscolor" >
-                <label for="webTextColor">Text Color</label>
+                <label for="webTextColor" style="padding-bottom: 5px">Text Color</label>
               </div>
             </div>
             <div class="row">
@@ -224,7 +219,7 @@
 
         <div id="server-ops" class="col s12" style="padding: 15px;">
           <div class="row">
-            Gazee Version: ${gazee_version}<br />
+            Gazee Version: <span id="gazee-version">${gazee_version}</span><br />
             Python Version: ${'.'.join(map(str,python_version[:3]))}
           </div>
           <div class="row">
@@ -256,56 +251,99 @@
             $("#update-app-submit").click(function() {
               $.ajax({
                 url: "saveSettings",
-                data: $("#server-settings-form").serialize()
+                data: $("#server-settings-form").serialize(),
+                success: function() {
+                  Materialize.toast("Settings saved. Restarting server.", 4000);
+                  $.get("restart");
+                }
               });
             });
             $("#scan-comics-submit").click(function() {
               $.ajax({
-                url: "comicScan"
+                url: "comicScan",
+                success: function() {
+                  Materialize.toast("Comic scan started.", 4000);
+                  $("#scan-status").text("In Progress");
+                }
               });
             });
             $("#change-pass-submit").click(function() {
               $.ajax({
                 url: "changePassword",
-                data: $("#change-password-form").serialize()
+                data: $("#change-password-form").serialize(),
+                success: function() {
+                  Materialize.toast("Password updated for " + $("#user-password").val() + ".", 4000);
+                }
               });
             });
             $("#new-user-submit").click(function() {
               $.ajax({
                 url: "newUser",
-                data: $("#new-user-form").serialize()
+                data: $("#new-user-form").serialize(),
+                success: function(response) {
+                  response = JSON.parse(response);
+                  var user = $("#new-username");
+                  var type = $("input[name=usertype]:checked");
+                  if (response['added']) {
+                    Materialize.toast("New " + type.val() + " " + user.val() + " added.", 4000);
+                    $("#user-rows").append('                    <tr id="user-' + user.val() + '">\n' +
+                    '                      <td>' + user.val() + '</td>\n' +
+                    '                      <td>' + type.val() + '</td>\n' +
+                    '                    </tr>');
+                  }
+                  else {
+                    Materialize.toast("User " + user.val() + " already exists.", 4000);
+                  }
+
+                  user.val("").blur();
+                  $("#new-user-password").val("").blur();
+                  type.prop("checked", false);
+                }
               });
             });
             $("#del-user-submit").click(function() {
               $.ajax({
                 url: "delUser",
                 data: $("#del-user-form").serialize(),
-                success: function(response) {
-                  var user = $("#user-del").val();
-                  Materialize.toast("User " + user + " deleted", 4000);
-                  $("#user-" + user).remove();
+                success: function() {
+                  var user = $("#user-del");
+                  Materialize.toast("User " + user.val() + " deleted.", 4000);
+                  $("#user-" + user.val()).remove();
+                  user.val("").blur();
                 }
               });
             });
             $("#change-theme-submit").click(function() {
               $.ajax({
                 url: "changeTheme",
-                data: $("#change-theme-form").serialize()
+                data: $("#change-theme-form").serialize(),
+                success: function() {
+                  Materialize.toast("Theme updated.", 4000);
+                }
               });
             });
             $("#shutdown-server").click(function() {
-              $.ajax({
-                url: "shutdown"
-              });
+              Materialize.toast("Shutting down server.", 4000);
+              $.get("shutdown");
             });
             $("#restart-server").click(function() {
-              $.ajax({
-                url: "restart"
-              });
+              Materialize.toast("Restarting server.", 4000);
+              $.get("restart");
             });
             $("#update-server").click(function() {
-              $.ajax({
-                url: "updateGazee"
+              $.get("updateGazee", function(response) {
+                response = JSON.parse(response);
+                if (response['update'] && response['current_version'] === response['latest_version']) {
+                  Materialize.toast("Server updated to version " + response['latest_version'] + ". Restarting Server.", 4000);
+                  $("#gazee-version").text(response['latest_version']);
+                  $.get("restart");
+                }
+                else if (!response['update'] && response['current_version'] !== response['latest_version']) {
+                  Materialize.toast("Failed to update to latest version. Check log.", 4000);
+                }
+                else {
+                  Materialize.toast("Server up to date.", 4000);
+                }
               });
             });
           });


### PR DESCRIPTION
Finishes up the second point in and closes #18

Adds Materialize.toasts to all buttons on the settings page and does some further actions on certain ajax requests:
1. Create user -> adds user to the table of users, clears the form
2. Delete user -> removes user from the table of users, clears the form
3. Update version -> changes version string
4. Hitting comic scan -> Change comic scan text to be "In-Progress"

I fixed a bug where hitting restart was actually creating a new python process separate from the original terminal process which means that you always would need to kill the process via its pid/killall.

I strengthened the integrity of the Users table as you could have an admin and user with same username, though then deleting it/changing the password would affect all users. Restricted the table to have username be a primary key.